### PR TITLE
Frontend: read session token from URL; fix RGS mock-mode

### DIFF
--- a/services/rgsApiService.ts
+++ b/services/rgsApiService.ts
@@ -57,8 +57,7 @@ class RgsApiClient {
         /* ---- Determine if we should fall back to mock mode ---- */
         this.useMock =
             !authToken ||
-            authToken === 'SESSION_TOKEN_FROM_STAKE_PLATFORM' ||
-            (/^https?:\/\//.test(rgsUrl) && rgsUrl.includes('rgs.stake-engine.com'));
+            authToken === 'SESSION_TOKEN_FROM_STAKE_PLATFORM';
 
         /* Prepare mock data */
         if (this.useMock) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,9 +109,17 @@ const App: React.FC = () => {
                 const socialMode = urlParams.get('social') === 'true';
                 setSocialMode(socialMode);
 
-                // For local development with the mock RGS service, we use a placeholder token.
-                // In a real deployment, the session token would be read from the URL.
-                rgsApiService.initialize("SESSION_TOKEN_FROM_STAKE_PLATFORM", rgsUrl);
+                // Retrieve session token from query params (supports several key variants) or fall back to placeholder.
+                const sessionToken =
+                    urlParams.get('sessionID') ??
+                    urlParams.get('sessionId') ??
+                    urlParams.get('session_id') ??
+                    urlParams.get('session') ??
+                    urlParams.get('token') ??
+                    'SESSION_TOKEN_FROM_STAKE_PLATFORM';
+
+                // Initialize RGS client with resolved session token and base URL.
+                rgsApiService.initialize(sessionToken, rgsUrl);
 
                 // Initialize audio service
                 await audioService.init();


### PR DESCRIPTION
Droid-assisted PR: \n- Read session token from URL (sessionID/sessionId/session_id/session/token) and pass to RGS client.\n- Stop forcing mock mode for rgs.stake-engine.com; only mock when token missing/placeholder.